### PR TITLE
export renderBody

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ const layout = (config) => ({
     </div>
     `
     ),
+  renderBody,
   authWrap: ({
     title,
     alerts, //TODO


### PR DESCRIPTION
is needed by the app to replace 'page-inner-content'